### PR TITLE
First cut of message processing logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,10 @@
-pub(crate) mod messages;
-mod processor;
+extern crate core;
 
-pub use processor::run;
+pub(crate) mod messages;
+pub(crate) mod processor;
+pub(crate) mod responses;
+mod runner;
+
+pub use messages::Record;
+pub use processor::Processor;
+pub use runner::run;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -26,12 +26,12 @@ pub(crate) enum Message {
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct InitPayload {
-    shard_id: String,
+    pub shard_id: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct RecordPayload {
+pub struct Record {
     #[serde(rename = "data", with = "Base64Standard")]
     raw_data: Vec<u8>,
     partition_key: String,
@@ -43,7 +43,7 @@ pub(crate) struct RecordPayload {
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ProcessRecordPayload {
-    records: Vec<RecordPayload>,
+    pub records: Vec<Record>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,57 +1,6 @@
-use crate::messages::{parse_message, Message};
-use serde::Serialize;
-use std::io;
-use std::io::Write;
+use crate::messages::Record;
 
-fn read_next() -> String {
-    let mut input = String::new();
-    if io::stdin().read_line(&mut input).is_err() {
-        println!("{input}");
-    }
-
-    input
-}
-
-fn write_status(message: StatusMessage) {
-    let mut out = io::stdout();
-    let mut payload = serde_json::to_vec(&message).unwrap();
-    payload.push(b'\n');
-    out.write_all(payload.as_slice()).unwrap();
-    out.flush().unwrap();
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct StatusMessage {
-    action: String,
-    response_for: String,
-}
-
-impl StatusMessage {
-    fn new_for_message(message: Message) -> Self {
-        let response_for = match message {
-            Message::Initialize(_) => "initialize",
-            Message::ProcessRecords(_) => "processRecords",
-            Message::Checkpoint(_) => "checkpoint",
-            Message::LeaseLost => "leaseLost",
-            Message::ShardEnded(_) => "shardEnded",
-            Message::ShutdownRequested(_) => "shutdownRequested",
-        }
-        .to_string();
-
-        Self {
-            action: "status".to_string(),
-            response_for,
-        }
-    }
-}
-
-pub fn run() {
-    loop {
-        let next = read_next();
-        let message = parse_message(&next).unwrap();
-        let status_message = StatusMessage::new_for_message(message);
-
-        write_status(status_message);
-    }
+pub trait Processor {
+    fn initialize(&mut self, shard_id: &str);
+    fn process_records(&mut self, data: &[Record]);
 }

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -1,0 +1,44 @@
+use crate::messages::Message;
+use std::io;
+use std::io::Write;
+
+use serde::Serialize;
+
+pub(crate) fn acknowledge_message(message: Message) {
+    let status_message = StatusResponse::for_message(message);
+    write_status(status_message);
+}
+
+fn write_status(message: StatusResponse) {
+    let mut out = io::stdout();
+    let mut payload = serde_json::to_vec(&message).unwrap();
+    payload.push(b'\n');
+    out.write_all(payload.as_slice()).unwrap();
+    out.flush().unwrap();
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatusResponse {
+    action: String,
+    response_for: String,
+}
+
+impl StatusResponse {
+    pub fn for_message(message: Message) -> Self {
+        let response_for = match message {
+            Message::Initialize(_) => "initialize",
+            Message::ProcessRecords(_) => "processRecords",
+            Message::Checkpoint(_) => "checkpoint",
+            Message::LeaseLost => "leaseLost",
+            Message::ShardEnded(_) => "shardEnded",
+            Message::ShutdownRequested(_) => "shutdownRequested",
+        }
+        .to_string();
+
+        Self {
+            action: "status".to_string(),
+            response_for,
+        }
+    }
+}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,0 +1,35 @@
+use std::io;
+
+use crate::messages::{parse_message, InitPayload, Message, ProcessRecordPayload};
+use crate::processor::Processor;
+use crate::responses::acknowledge_message;
+
+fn read_next() -> String {
+    let mut input = String::new();
+    if io::stdin().read_line(&mut input).is_err() {
+        println!("{input}");
+    }
+
+    input
+}
+
+pub fn run(processor: &mut impl Processor) {
+    loop {
+        let next = read_next();
+        let message = parse_message(&next).unwrap();
+        match &message {
+            Message::Initialize(InitPayload { shard_id }) => processor.initialize(shard_id),
+            Message::ProcessRecords(ProcessRecordPayload { records }) => {
+                processor.process_records(records)
+            }
+            Message::LeaseLost => {}
+            Message::ShardEnded(_) => {}
+            Message::ShutdownRequested(_) => {}
+            // This should only be sent in response to a checkpoint message sent to the daemon,
+            // we should never receive it unexpectedly here
+            Message::Checkpoint(_) => panic!("unexpected checkpointing"),
+        }
+
+        acknowledge_message(message);
+    }
+}


### PR DESCRIPTION
Processing logic that reads all message types from stdin and immediately acknowledges to stdout.

This isn't production quality stuff or suitable format for the library, but it's allowed me to spin up a dummy app without having to expose all the internal structs and enums. Confirmed that the protocol is working as expected!

It also serves as a good starting point for how the processes need to communicate.