### PR TITLE
Input/output abstraction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub(crate) mod processor;
 pub mod reader;
 pub(crate) mod responses;
 mod runner;
+pub mod writer;
 
 pub use messages::Record;
 pub use processor::Processor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,9 @@
-extern crate core;
-
 pub(crate) mod messages;
 pub(crate) mod processor;
+pub mod reader;
 pub(crate) mod responses;
 mod runner;
 
 pub use messages::Record;
 pub use processor::Processor;
-pub use runner::run;
+pub use runner::{run, tick};

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -31,15 +31,15 @@ pub(crate) struct InitPayload {
     pub shard_id: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Record {
     #[serde(rename = "data", with = "Base64Standard")]
-    raw_data: Vec<u8>,
-    partition_key: String,
-    sequence_number: String,
-    sub_sequence_number: Option<u64>,
-    approximate_arrival_timestamp: f64,
+    pub raw_data: Vec<u8>,
+    pub partition_key: String,
+    pub sequence_number: String,
+    pub sub_sequence_number: Option<u64>,
+    pub approximate_arrival_timestamp: f64,
 }
 
 impl Record {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,0 +1,26 @@
+use std::io;
+
+use eyre::Result;
+
+pub trait InputReader {
+    fn next(&mut self) -> Result<String>;
+}
+
+pub struct StdinReader {
+    stdin: io::Stdin,
+}
+
+impl StdinReader {
+    pub(crate) fn new() -> Self {
+        Self { stdin: io::stdin() }
+    }
+}
+
+impl InputReader for StdinReader {
+    fn next(&mut self) -> Result<String> {
+        let mut input = String::new();
+        self.stdin.read_line(&mut input)?;
+
+        Ok(input)
+    }
+}

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -1,31 +1,10 @@
-use std::io;
-use std::io::Write;
-
-use eyre::Result;
 use serde::Serialize;
 
 use crate::messages::Message;
 
-pub(crate) fn acknowledge_message(message: Message) -> Result<()> {
-    let status_message = StatusResponse::for_message(message);
-    write_status(status_message)?;
-
-    Ok(())
-}
-
-fn write_status(message: StatusResponse) -> Result<()> {
-    let mut out = io::stdout();
-    let mut payload = serde_json::to_vec(&message)?;
-    payload.push(b'\n');
-    out.write_all(payload.as_slice())?;
-    out.flush()?;
-
-    Ok(())
-}
-
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct StatusResponse {
+pub(crate) struct StatusResponse {
     action: String,
     response_for: String,
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,26 +1,19 @@
-use std::io;
-
 use eyre::Result;
 
 use crate::messages::{parse_message, InitPayload, Message, ProcessRecordPayload};
 use crate::processor::Processor;
+use crate::reader::{InputReader, StdinReader};
 use crate::responses::acknowledge_message;
 
-fn read_next() -> Result<String> {
-    let mut input = String::new();
-    io::stdin().read_line(&mut input)?;
-
-    Ok(input)
-}
-
 pub fn run(processor: &mut impl Processor) {
+    let mut reader = StdinReader::new();
     loop {
-        tick(processor).unwrap();
+        tick(processor, &mut reader).unwrap();
     }
 }
 
-fn tick(processor: &mut impl Processor) -> Result<()> {
-    let next = read_next()?;
+pub fn tick(processor: &mut impl Processor, input_reader: &mut impl InputReader) -> Result<()> {
+    let next = input_reader.next()?;
     let message = parse_message(&next)?;
     match &message {
         Message::Initialize(InitPayload { shard_id }) => processor.initialize(shard_id),

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,0 +1,36 @@
+use std::io;
+use std::io::{Stdout, Write};
+
+use crate::responses::StatusResponse;
+use eyre::Result;
+
+pub(crate) fn write_status(writer: &mut impl OutputWriter, message: StatusResponse) -> Result<()> {
+    let mut payload = serde_json::to_vec(&message)?;
+    payload.push(b'\n');
+    writer.write(payload.as_slice())?;
+
+    Ok(())
+}
+
+pub trait OutputWriter {
+    fn write(&mut self, payload: &[u8]) -> Result<()>;
+}
+
+pub struct StdoutWriter {
+    out: Stdout,
+}
+
+impl StdoutWriter {
+    pub(crate) fn new() -> Self {
+        Self { out: io::stdout() }
+    }
+}
+
+impl OutputWriter for StdoutWriter {
+    fn write(&mut self, payload: &[u8]) -> Result<()> {
+        self.out.write_all(payload)?;
+        self.out.flush()?;
+
+        Ok(())
+    }
+}

--- a/tests/mocks/mock_processor.rs
+++ b/tests/mocks/mock_processor.rs
@@ -1,0 +1,43 @@
+use amazon_kinesis_client::{Processor, Record};
+
+pub struct MockProcessor {
+    pub shard: Option<String>,
+    pub records: Vec<Record>,
+    pub lease_lost: bool,
+    pub shard_ended: bool,
+    pub shutdown_requested: bool,
+}
+
+impl MockProcessor {
+    pub fn new() -> Self {
+        Self {
+            shard: None,
+            records: vec![],
+            lease_lost: false,
+            shard_ended: false,
+            shutdown_requested: false,
+        }
+    }
+}
+
+impl Processor for MockProcessor {
+    fn initialize(&mut self, shard_id: &str) {
+        self.shard = Some(shard_id.to_owned())
+    }
+
+    fn process_records(&mut self, data: &[Record]) {
+        for record in data {
+            self.records.push((*record).clone())
+        }
+    }
+
+    fn lease_lost(&mut self) {
+        self.lease_lost = true;
+    }
+    fn shard_ended(&mut self) {
+        self.shard_ended = true;
+    }
+    fn shutdown_requested(&mut self) {
+        self.shutdown_requested = true;
+    }
+}

--- a/tests/mocks/mock_reader.rs
+++ b/tests/mocks/mock_reader.rs
@@ -1,0 +1,33 @@
+use amazon_kinesis_client::reader::InputReader;
+use std::collections::VecDeque;
+
+pub struct MockReader {
+    lines: VecDeque<String>,
+}
+
+impl MockReader {
+    pub fn new() -> Self {
+        Self {
+            lines: VecDeque::new(),
+        }
+    }
+
+    pub fn with_input(input: String) -> Self {
+        let mut reader = Self::new();
+        reader.add_input(input);
+
+        reader
+    }
+
+    pub fn add_input(&mut self, input: String) {
+        self.lines.push_back(input)
+    }
+}
+
+impl InputReader for MockReader {
+    fn next(&mut self) -> eyre::Result<String> {
+        self.lines
+            .pop_front()
+            .ok_or(eyre::eyre!("no input to read"))
+    }
+}

--- a/tests/mocks/mock_writer.rs
+++ b/tests/mocks/mock_writer.rs
@@ -1,0 +1,20 @@
+use amazon_kinesis_client::writer::OutputWriter;
+
+pub struct MockWriter {
+    pub outputs: Vec<String>,
+}
+
+impl MockWriter {
+    pub(crate) fn new() -> Self {
+        Self { outputs: vec![] }
+    }
+}
+
+impl OutputWriter for MockWriter {
+    fn write(&mut self, payload: &[u8]) -> eyre::Result<()> {
+        let output = std::str::from_utf8(payload)?;
+        self.outputs.push(output.to_owned());
+
+        Ok(())
+    }
+}

--- a/tests/mocks/mod.rs
+++ b/tests/mocks/mod.rs
@@ -1,0 +1,2 @@
+pub mod mock_processor;
+pub mod mock_reader;

--- a/tests/mocks/mod.rs
+++ b/tests/mocks/mod.rs
@@ -1,2 +1,3 @@
 pub mod mock_processor;
 pub mod mock_reader;
+pub mod mock_writer;

--- a/tests/tick_tests.rs
+++ b/tests/tick_tests.rs
@@ -4,22 +4,31 @@ use amazon_kinesis_client::tick;
 
 use crate::mocks::mock_processor::MockProcessor;
 use crate::mocks::mock_reader::MockReader;
+use crate::mocks::mock_writer::MockWriter;
 
-fn tick_into_processor(message: &str) -> MockProcessor {
-    let mut reader = MockReader::with_input(message.to_string());
+fn tick_into_processor(message: &str) -> (MockProcessor, MockWriter) {
     let mut processor = MockProcessor::new();
+    let mut reader = MockReader::with_input(message.to_string());
+    let mut writer = MockWriter::new();
 
-    tick(&mut processor, &mut reader).unwrap();
+    tick(&mut processor, &mut reader, &mut writer).unwrap();
 
-    processor
+    (processor, writer)
+}
+
+fn assert_status_response(writer: &MockWriter, status: &str) {
+    let expected_out = format!("{{\"action\":\"status\",\"responseFor\":\"{status}\"}}\n");
+    assert_eq!(writer.outputs.last(), Some(&expected_out))
 }
 
 #[test]
 fn test_tick_initialize() {
     let message = "{\"action\" :\"initialize\", \"shardId\": \"shard1\"}";
-    let processor = tick_into_processor(message);
+    let (processor, writer) = tick_into_processor(message);
 
     assert_eq!(processor.shard, Some("shard1".to_owned()));
+    assert_eq!(writer.outputs.len(), 1);
+    assert_status_response(&writer, "initialize");
 }
 
 #[test]
@@ -30,35 +39,43 @@ fn test_tick_new_record() {
             \"partitionKey\": \"1\",\
             \"sequenceNumber\": \"49590338271490256608559692538361571095921575989136588898\",\
             \"approximateArrivalTimestamp\": 1570887011763.01}]}";
-    let processor = tick_into_processor(message);
+    let (processor, writer) = tick_into_processor(message);
 
     let record = processor.records.last().unwrap();
     assert_eq!(
         std::str::from_utf8(record.raw_data.as_slice()).unwrap(),
         "Hello, this is a test."
-    )
+    );
+    assert_eq!(writer.outputs.len(), 1);
+    assert_status_response(&writer, "processRecords");
 }
 
 #[test]
 fn test_tick_lease_lost() {
     let message = "{\"action\": \"leaseLost\"}";
-    let processor = tick_into_processor(message);
+    let (processor, writer) = tick_into_processor(message);
 
     assert!(processor.lease_lost);
+    assert_eq!(writer.outputs.len(), 1);
+    assert_status_response(&writer, "leaseLost");
 }
 
 #[test]
 fn test_tick_shard_ended() {
     let message = "{\"action\": \"shardEnded\", \"checkpoint\": \"1234\"}";
-    let processor = tick_into_processor(message);
+    let (processor, writer) = tick_into_processor(message);
 
     assert!(processor.shard_ended);
+    assert_eq!(writer.outputs.len(), 1);
+    assert_status_response(&writer, "shardEnded");
 }
 
 #[test]
 fn test_tick_shutdown_requested() {
     let message = "{\"action\": \"shutdownRequested\", \"checkpoint\": \"1234\"}";
-    let processor = tick_into_processor(message);
+    let (processor, writer) = tick_into_processor(message);
 
     assert!(processor.shutdown_requested);
+    assert_eq!(writer.outputs.len(), 1);
+    assert_status_response(&writer, "shutdownRequested");
 }

--- a/tests/tick_tests.rs
+++ b/tests/tick_tests.rs
@@ -1,0 +1,64 @@
+mod mocks;
+
+use amazon_kinesis_client::tick;
+
+use crate::mocks::mock_processor::MockProcessor;
+use crate::mocks::mock_reader::MockReader;
+
+fn tick_into_processor(message: &str) -> MockProcessor {
+    let mut reader = MockReader::with_input(message.to_string());
+    let mut processor = MockProcessor::new();
+
+    tick(&mut processor, &mut reader).unwrap();
+
+    processor
+}
+
+#[test]
+fn test_tick_initialize() {
+    let message = "{\"action\" :\"initialize\", \"shardId\": \"shard1\"}";
+    let processor = tick_into_processor(message);
+
+    assert_eq!(processor.shard, Some("shard1".to_owned()));
+}
+
+#[test]
+fn test_tick_new_record() {
+    let message = "{\"action\": \"processRecords\", \
+        \"records\": [{\
+            \"data\": \"SGVsbG8sIHRoaXMgaXMgYSB0ZXN0Lg==\",\
+            \"partitionKey\": \"1\",\
+            \"sequenceNumber\": \"49590338271490256608559692538361571095921575989136588898\",\
+            \"approximateArrivalTimestamp\": 1570887011763.01}]}";
+    let processor = tick_into_processor(message);
+
+    let record = processor.records.last().unwrap();
+    assert_eq!(
+        std::str::from_utf8(record.raw_data.as_slice()).unwrap(),
+        "Hello, this is a test."
+    )
+}
+
+#[test]
+fn test_tick_lease_lost() {
+    let message = "{\"action\": \"leaseLost\"}";
+    let processor = tick_into_processor(message);
+
+    assert!(processor.lease_lost);
+}
+
+#[test]
+fn test_tick_shard_ended() {
+    let message = "{\"action\": \"shardEnded\", \"checkpoint\": \"1234\"}";
+    let processor = tick_into_processor(message);
+
+    assert!(processor.shard_ended);
+}
+
+#[test]
+fn test_tick_shutdown_requested() {
+    let message = "{\"action\": \"shutdownRequested\", \"checkpoint\": \"1234\"}";
+    let processor = tick_into_processor(message);
+
+    assert!(processor.shutdown_requested);
+}


### PR DESCRIPTION
We don't need to merge this if you don't like this.

What I was trying to do is creating abstractions over inputs and outputs, like the Python library does. The immediate benefit is that I could write integration tests, but I'm also awaiting response from AWS about potentially using sockets or some other way of communicating between the daemon and the processor, which this would allow to easily implement.

In addition to the new tests, I also tested the changes with the dummy app.